### PR TITLE
KLayout PyCell for rhigh: label contains rpnd, should be rhigh

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/rhigh_code.py
+++ b/ihp-sg13g2/libs.tech/klayout/python/sg13g2_pycell_lib/ihp/rhigh_code.py
@@ -476,7 +476,7 @@ class rhigh(DloGen):
         # create virtuel l for CbResCalc
         lcalc = (l*stripes+contactpush*2+lcor)/stripes
         resistance = CbResCalc('R', 0, lcalc*1e-6, w*1e-6, b, ps*1e-6, Cell)
-        labeltext = 'rpnd r={0:.3f}'.format(resistance)
+        labeltext = 'rhigh r={0:.3f}'.format(resistance)
         labelpos = Point(w/2, l/2)
         labelheight = 0.1
         if w > l :


### PR DESCRIPTION
Official PDK tickets are pending: 
   - PR: https://github.com/IHP-GmbH/IHP-Open-PDK/pull/742
   - Issue: https://github.com/IHP-GmbH/IHP-Open-PDK/issues/741
In the meantime we merge this into our `dev` branch
