### PR TITLE
Add cli options

### DIFF
--- a/ihp-sg13g2/libs.tech/qucs-s/install.py
+++ b/ihp-sg13g2/libs.tech/qucs-s/install.py
@@ -2,14 +2,14 @@
 
 ########################################################################
 #
-# Copyright 2024 IHP PDK Authors
-# 
+# Copyright 2024-2026 IHP PDK Authors
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,31 +18,34 @@
 #
 ########################################################################
 
-
 import shutil
 import os
 import subprocess
 import logging
+import argparse
 
-
-def exec_app_in_directory(command, directory):
+def exec_app_in_directory(cmd, directory):
     try:
-        subprocess.run(command, cwd=directory, shell=True, check=True)
+        subprocess.run(cmd, cwd=directory, shell=True, check=True)
     except subprocess.CalledProcessError as e:
         print(f"Error executing command in directory {directory}: {e}")
 
-def is_program_installed(program_name):
+def is_program_installed(program):
     try:
-        subprocess.run([program_name, "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            [program, "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
         return True
     except FileNotFoundError:
         return False
 
-
 def copy_files(source_dir, destination_dir):
     # Get a list of files in the source directory
     files = os.listdir(source_dir)
-    
+
     # Copy each file from source to destination
     for file in files:
         source_file = os.path.join(source_dir, file)
@@ -60,23 +63,22 @@ def info():
     """
     print(msg)
 
-
-def create_symlinks(source_directory, destination_directory):
+def create_symlinks(source_dir, destination_dir):
     """
-    Creates symbolic links for all files in source_directory inside destination_directory.
+    Creates symbolic links for all files in source_dir inside destination_dir.
     """
     # Ensure both directories exist
-    if not os.path.exists(source_directory):
-        print(f"Error: Source directory '{source_directory}' does not exist.")
+    if not os.path.exists(source_dir):
+        print(f"Error: Source directory '{source_dir}' does not exist.")
         return
-    
-    if not os.path.exists(destination_directory):
-        os.makedirs(destination_directory)
+
+    if not os.path.exists(destination_dir):
+        os.makedirs(destination_dir)
 
     # Iterate over files in the source directory
-    for file_name in os.listdir(source_directory):
-        source_path = os.path.join(source_directory, file_name)
-        dest_path = os.path.join(destination_directory, file_name)
+    for file_name in os.listdir(source_dir):
+        source_path = os.path.join(source_dir, file_name)
+        dest_path = os.path.join(destination_dir, file_name)
 
         # Only create symlinks for files
         if os.path.isfile(source_path):
@@ -89,63 +91,96 @@ def create_symlinks(source_directory, destination_directory):
             except OSError as e:
                 print(f"Error creating symlink for {source_path}: {e}")
 
-
 if __name__ == "__main__":
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="Install Qucs-S PDK files")
+    parser.add_argument(
+        "--no-model-compile",
+        action="store_true",
+        help="Skip Verilog-A model compilation step",
+    )
+    workspace_group = parser.add_mutually_exclusive_group()
+    workspace_group.add_argument(
+        "--no-qucs-workspace",
+        action="store_true",
+        help="Skip QucsWorkspace directory setup, only setup .qucs",
+    )
+    workspace_group.add_argument(
+        "--no-qucs-dir",
+        action="store_true",
+        help="Skip .qucs directory setup, only setup QucsWorkspace",
+    )
+    args = parser.parse_args()
+
     # Example usage:
     info()
-    
+
     # Check if 'Qucs-S' tool is available
-    program_name = "qucs-s"
-    if not is_program_installed(program_name):
-        logging.error(f"{program_name} is not installed.")
+    PROGRAM_NAME = "qucs-s"
+    if not is_program_installed(PROGRAM_NAME):
+        logging.error("%s is not installed.", PROGRAM_NAME)
         exit(1)
-    
+
     # Check if PDK_ROOT env variable exists
     pdk_root = os.environ.get("PDK_ROOT")
-    if pdk_root == None:
+    if pdk_root is None:
         logging.error("Setup PDK_ROOT environment variable to IHP-Open-PDK location")
         exit(1)
 
     userhome = os.environ.get("HOME")
-    
+
     # Supporting two variants of Qucs-S default workspace
-    for qucs_workspace in ['/.qucs/', '/QucsWorkspace/']:
-    
+    workspaces = ["/.qucs/", "/QucsWorkspace/"]
+    if args.no_qucs_workspace:
+        workspaces = ["/.qucs/"]
+    if args.no_qucs_dir:
+        workspaces = ["/QucsWorkspace/"]
+
+    for qucs_workspace in workspaces:
+
         print(f"Preparing $HOME{qucs_workspace} directory ...")
-        print("#############################################\n")    
+        print("#############################################\n")
         source_directory = pdk_root + "/ihp-sg13g2/libs.tech/qucs-s/user_lib"
         # Check if the source directory exists
         if not os.path.exists(source_directory):
-            logging.error(f"Source directory '{source_directory}' does not exist.")
+            logging.error("Source directory '%s' does not exist.", source_directory)
             exit(1)
-        
+
         destination_directory = userhome + qucs_workspace + "user_lib"
-        
+
         # Check if the destination directory exists, if not, create it
         if not os.path.exists(destination_directory):
             os.makedirs(destination_directory)
             print(f"Destination directory '{destination_directory}' created.")
-        
+
         create_symlinks(source_directory, destination_directory)
-        
+
         # Copy examples to "Qucs Home" (<userhome>/[.qucs|QucsWorkspace]/)
         print("Copying examples into Qucs-S Home...")
         source_directory = pdk_root + "/ihp-sg13g2/libs.tech/qucs-s/examples"
-        destination_directory = userhome + qucs_workspace + "IHP-Open-PDK-SG13G2-Examples_prj"
+        destination_directory = (
+            userhome + qucs_workspace + "IHP-Open-PDK-SG13G2-Examples_prj"
+        )
 
         if not os.path.exists(destination_directory):
             os.makedirs(destination_directory)
 
         copy_files(source_directory, destination_directory)
-        
+
         print("Examples copied")
         print("\n\n#############################################")
         print("              IMPORTANT NOTE")
         print("#############################################\n")
-        print("Before using the PDK example schematics, you must add the PDK library path to the Qucs-S search path list.\n")
-        print("Please read the instructions provided in " + destination_directory + "/README.md\n")
+        print(
+            "Before using the PDK example schematics, you must add the PDK library path to the Qucs-S search path list.\n"
+        )
+        print(
+            "Please read the instructions provided in "
+            + destination_directory
+            + "/README.md\n"
+        )
         print("#############################################\n")
-       
+
         original_file = pdk_root + "/ihp-sg13g2/libs.tech/ngspice/.spiceinit"
         symbolic_link = userhome + "/.spiceinit"
         # Create the symbolic link to ngspice global settings file
@@ -165,46 +200,61 @@ if __name__ == "__main__":
                 print(f"Symbolic link '{symbolic_link}' created successfully.\n")
             except OSError as e:
                 print(f"Failed to create symbolic link: {e}")
-        
+
         # Post-processing example schematics
-        program_name = "sed"
-        if is_program_installed(program_name):
-            command = f"sed -i 's/<qucs_workspace>{qucs_workspace}' *.sch"
-            exec_app_in_directory(command, destination_directory)
+        PROGRAM_NAME = "sed"
+        if is_program_installed(PROGRAM_NAME):
+            COMMAND = f"sed -i 's/<qucs_workspace>{qucs_workspace}' *.sch"
+            exec_app_in_directory(COMMAND, destination_directory)
         else:
-            logging.error(f"{program_name} is not installed.")
+            logging.error("%s is not installed.", PROGRAM_NAME)
             exit(1)
-                
+
     # Compiling Verilog-A models
-    print("Compiling Verilog-A models ...")
-    destination_directory = pdk_root + "/ihp-sg13g2/libs.tech/ngspice/osdi"
-    
-    if not os.path.exists(destination_directory):
-        os.makedirs(destination_directory)
-    
-    program_name = "openvaf"
-    if is_program_installed(program_name):
-        source_directory = pdk_root + "/ihp-sg13g2/libs.tech/verilog-a/psp103"
-        command = "openvaf psp103_nqs.va --output " + destination_directory + "/psp103_nqs.osdi"    
-        print(f"{program_name} is available and about to run the command '{command}' in a location: {source_directory} ")	
-        exec_app_in_directory(command, source_directory)
-        command = "openvaf psp103.va --output " + destination_directory + "/psp103.osdi"    
-        print(f"{program_name} is available and about to run the command '{command}' in a location: {source_directory} ")	
-        exec_app_in_directory(command, source_directory)
-        source_directory = pdk_root + "/ihp-sg13g2/libs.tech/verilog-a/r3_cmc"
-        command = "openvaf r3_cmc.va --output " + destination_directory + "/r3_cmc.osdi"    
-        print(f"{program_name} is available and about to run the command '{command}' in a location: {source_directory} ")	
-        exec_app_in_directory(command, source_directory)
-        source_directory = pdk_root + "/ihp-sg13g2/libs.tech/verilog-a/mosvar"
-        command = "openvaf mosvar.va --output " + destination_directory + "/mosvar.osdi"    
-        print(f"{program_name} is available and about to run the command '{command}' in a location: {source_directory} ")	
-        exec_app_in_directory(command, source_directory)
+    if args.no_model_compile:
+        print("Skipping Verilog-A model compilation (--no-model-compile specified)")
     else:
-        logging.error(f"{program_name} is not installed.")
-        exit(1)
-                
-                
-                
-                
-                
-                
+        print("Compiling Verilog-A models ...")
+        destination_directory = pdk_root + "/ihp-sg13g2/libs.tech/ngspice/osdi"
+
+        if not os.path.exists(destination_directory):
+            os.makedirs(destination_directory)
+
+        PROGRAM_NAME = "openvaf"
+        if is_program_installed(PROGRAM_NAME):
+            source_directory = pdk_root + "/ihp-sg13g2/libs.tech/verilog-a/psp103"
+            command = (
+                "openvaf psp103_nqs.va --output "
+                + destination_directory
+                + "/psp103_nqs.osdi"
+            )
+            print(
+                f"{PROGRAM_NAME} is available and about to run the command '{command}' in a location: {source_directory} "
+            )
+            exec_app_in_directory(command, source_directory)
+            command = (
+                "openvaf psp103.va --output " + destination_directory + "/psp103.osdi"
+            )
+            print(
+                f"{PROGRAM_NAME} is available and about to run the command '{command}' in a location: {source_directory} "
+            )
+            exec_app_in_directory(command, source_directory)
+            source_directory = pdk_root + "/ihp-sg13g2/libs.tech/verilog-a/r3_cmc"
+            command = (
+                "openvaf r3_cmc.va --output " + destination_directory + "/r3_cmc.osdi"
+            )
+            print(
+                f"{PROGRAM_NAME} is available and about to run the command '{command}' in a location: {source_directory} "
+            )
+            exec_app_in_directory(command, source_directory)
+            source_directory = pdk_root + "/ihp-sg13g2/libs.tech/verilog-a/mosvar"
+            command = (
+                "openvaf mosvar.va --output " + destination_directory + "/mosvar.osdi"
+            )
+            print(
+                f"{PROGRAM_NAME} is available and about to run the command '{command}' in a location: {source_directory} "
+            )
+            exec_app_in_directory(command, source_directory)
+        else:
+            logging.error("%s is not installed.", PROGRAM_NAME)
+            exit(1)

--- a/ihp-sg13g2/libs.tech/qucs-s/install.py
+++ b/ihp-sg13g2/libs.tech/qucs-s/install.py
@@ -99,6 +99,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Skip Verilog-A model compilation step",
     )
+    parser.add_argument(
+        "--no-qucs-check",
+        action="store_true",
+        help="Skip check if qucs-s binary exists",
+    )
     workspace_group = parser.add_mutually_exclusive_group()
     workspace_group.add_argument(
         "--no-qucs-workspace",
@@ -116,10 +121,11 @@ if __name__ == "__main__":
     info()
 
     # Check if 'Qucs-S' tool is available
-    PROGRAM_NAME = "qucs-s"
-    if not is_program_installed(PROGRAM_NAME):
-        logging.error("%s is not installed.", PROGRAM_NAME)
-        exit(1)
+    if not args.no_qucs_check:
+        PROGRAM_NAME = "qucs-s"
+        if not is_program_installed(PROGRAM_NAME):
+            logging.error("%s is not installed.", PROGRAM_NAME)
+            exit(1)
 
     # Check if PDK_ROOT env variable exists
     pdk_root = os.environ.get("PDK_ROOT")


### PR DESCRIPTION
This pull request refactors and enhances the `ihp-sg13g2/libs.tech/qucs-s/install.py` script to improve usability, maintainability, and user control over the installation process. The main changes include the addition of command-line arguments for more flexible execution, improved variable naming consistency, enhanced error handling, and code cleanup for better readability.

**Command-line interface and user control:**
* Introduced `argparse` to add command-line options, allowing users to skip model compilation (`--no-model-compile`), skip checking for the `qucs-s` binary (`--no-qucs-check`), and choose which workspace directories to set up (`--no-qucs-workspace` or `--no-qucs-dir`).

**Code quality and maintainability:**
* Refactored function and variable names for clarity and consistency (e.g., `command` to `cmd`, `program_name` to `PROGRAM_NAME`, `source_directory` to `source_dir`). [[1]](diffhunk://#diff-b625ac251f7939ddfc08c871d030d7887bb12843ea3189b701e03c853e2d13a1L21-L41) [[2]](diffhunk://#diff-b625ac251f7939ddfc08c871d030d7887bb12843ea3189b701e03c853e2d13a1L63-R81)
* Improved error messages and logging to use consistent formatting and more informative outputs. [[1]](diffhunk://#diff-b625ac251f7939ddfc08c871d030d7887bb12843ea3189b701e03c853e2d13a1L92-R152) [[2]](diffhunk://#diff-b625ac251f7939ddfc08c871d030d7887bb12843ea3189b701e03c853e2d13a1L170-L210)
* Cleaned up code formatting, removed unnecessary blank lines, and improved string concatenation for readability. [[1]](diffhunk://#diff-b625ac251f7939ddfc08c871d030d7887bb12843ea3189b701e03c853e2d13a1L134-R169) [[2]](diffhunk://#diff-b625ac251f7939ddfc08c871d030d7887bb12843ea3189b701e03c853e2d13a1L145-R187)

**Functionality improvements:**
* Added logic to allow mutually exclusive setup of `.qucs` and `QucsWorkspace` directories, based on user input.
* Enhanced the Verilog-A model compilation step to respect the new command-line flag and improved the execution flow for model compilation commands.

**License update:**
* Updated copyright years in the license header.