### PR TITLE
Add --compile-model-generic flag

### DIFF
--- a/ihp-sg13g2/libs.tech/verilog-a/openvaf-compile-va.sh
+++ b/ihp-sg13g2/libs.tech/verilog-a/openvaf-compile-va.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
-# Copyright 2023 The ngspice team
-# Authors: Holger Vogt, Dietmar Warning
+# Copyright 2023-2026 The ngspice team
+# Authors: Holger Vogt, Dietmar Warning, Harald Pretl
 # License: New BSD
+
+# Parse command line arguments
+TARGET_CPU_FLAG=""
+for arg in "$@"; do
+  case $arg in
+    --compile-model-generic)
+      TARGET_CPU_FLAG="--target_cpu generic"
+      shift
+      ;;
+  esac
+done
 
 DIRECTORY="../ngspice/osdi"
 
@@ -27,11 +38,9 @@ echo "======================================================================"
 echo "             Compiling VerilogA models using: '$COMPILER'             "
 echo "======================================================================"
 
-
-$COMPILER -D__NGSPICE__ -o $DIRECTORY/psp103.osdi psp103/psp103.va
-$COMPILER -D__NGSPICE__ -o $DIRECTORY/psp103_nqs.osdi psp103/psp103_nqs.va
-$COMPILER -D__NGSPICE__ -o $DIRECTORY/r3_cmc.osdi r3_cmc/r3_cmc.va
-$COMPILER -D__NGSPICE__ -o $DIRECTORY/mosvar.osdi mosvar/mosvar.va
+$COMPILER -D__NGSPICE__ $TARGET_CPU_FLAG -o $DIRECTORY/psp103.osdi psp103/psp103.va
+$COMPILER -D__NGSPICE__ $TARGET_CPU_FLAG -o $DIRECTORY/psp103_nqs.osdi psp103/psp103_nqs.va
+$COMPILER -D__NGSPICE__ $TARGET_CPU_FLAG -o $DIRECTORY/r3_cmc.osdi r3_cmc/r3_cmc.va
+$COMPILER -D__NGSPICE__ $TARGET_CPU_FLAG -o $DIRECTORY/mosvar.osdi mosvar/mosvar.va
 
 echo done
-


### PR DESCRIPTION
This pull request updates the `openvaf-compile-va.sh` script to improve flexibility and maintainability when compiling Verilog-A models. The main changes include adding support for a new command-line flag and updating copyright information.

**Enhancements to build process:**

* Added parsing for a `--compile-model-generic` command-line argument, which sets a `--target_cpu generic` flag for the compiler. This allows for more flexible compilation targeting different CPU architectures.
* Updated all compiler invocation commands to include the `$TARGET_CPU_FLAG`, ensuring the new flag is passed when specified.

**Maintenance and documentation:**

* Updated the copyright years and added Harald Pretl to the list of script authors.